### PR TITLE
Fix for new file naming convention

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,22 +12,19 @@ RUN apt-get update  \
     nano \
     python3-dev \
     build-essential \
-    && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV PATH=/root/.local/bin:$PATH
-
-RUN python3 -m pip install --upgrade pip
 
 WORKDIR /usr/src
 
 COPY requirements_on_edge.txt .
 
-# Need to install this separately to prevent CVToolkit deps from installing Torch
-RUN python3 -m pip install --no-deps git+https://github.com/Computer-Vision-Team-Amsterdam/CVToolkit.git
-
-RUN python3 -m pip install -r requirements_on_edge.txt
+# Need to install CVToolkit separately to prevent it from re-installing Torch
+RUN python3 -m pip install --upgrade pip \
+    && python3 -m pip install --no-deps git+https://github.com/Computer-Vision-Team-Amsterdam/CVToolkit.git \
+    && python3 -m pip install -r requirements_on_edge.txt
 
 COPY oor_on_edge oor_on_edge
 COPY config.yml config.yml

--- a/oor_on_edge/data_delivery_pipeline/components/data_delivery.py
+++ b/oor_on_edge/data_delivery_pipeline/components/data_delivery.py
@@ -16,6 +16,8 @@ from oor_on_edge.utils import (
 
 logger = logging.getLogger("data_delivery_pipeline")
 
+METADATA_N_FIELDS = 17  # The number of fields we want to preserve
+
 
 class DataDelivery:
     def __init__(self):
@@ -146,7 +148,9 @@ class DataDelivery:
                     )
                     detection_metadata_rows.extend(row_detection_metadata_rows)
                     filtered_frame_metadata_rows.append(
-                        [image_file_name] + row + self.model_and_code_version
+                        [image_file_name]
+                        + row[:METADATA_N_FIELDS]
+                        + self.model_and_code_version
                     )
                     images_delivered += 1
 

--- a/oor_on_edge/utils.py
+++ b/oor_on_edge/utils.py
@@ -52,7 +52,7 @@ def count_files_in_folder_tree(root_folder: pathlib.Path, file_type: str):
 
 def get_img_name_from_csv_row(csv_path, row):
     csv_path_split = csv_path.stem.split(sep="-", maxsplit=1)
-    img_name = f"0-{csv_path_split[1]}-{row[1]}.jpg"
+    img_name = f"0-{csv_path_split[1]}-{row[1].zfill(5)}.jpg"
     return img_name
 
 

--- a/oor_on_edge/utils.py
+++ b/oor_on_edge/utils.py
@@ -51,8 +51,11 @@ def count_files_in_folder_tree(root_folder: pathlib.Path, file_type: str):
 
 
 def get_img_name_from_csv_row(csv_path, row):
+    # Either this
     csv_path_split = csv_path.stem.split(sep="-", maxsplit=1)
     img_name = f"0-{csv_path_split[1]}-{row[1].zfill(5)}.jpg"
+    # Or this
+    # img_name = row[-1]
     return img_name
 
 

--- a/oor_on_edge/utils.py
+++ b/oor_on_edge/utils.py
@@ -51,10 +51,14 @@ def count_files_in_folder_tree(root_folder: pathlib.Path, file_type: str):
 
 
 def get_img_name_from_csv_row(csv_path, row):
-    # Either this
-    csv_path_split = csv_path.stem.split(sep="-", maxsplit=1)
-    img_name = f"0-{csv_path_split[1]}-{row[1].zfill(5)}.jpg"
-    # Or this
+    # OLD solution
+    # csv_path_split = csv_path.stem.split(sep="-", maxsplit=1)
+    # img_name = f"0-{csv_path_split[1]}-{row[1]}.jpg"
+
+    # NEW solution 11/11/2024
+    img_name = f"{csv_path.stem}-{row[1].zfill(5)}.jpg"
+
+    # Possible future solution
     # img_name = row[-1]
     return img_name
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "oor_on_edge"
-version = "1.0.1"
+version = "1.0.2"
 
 [tool.poetry]
 name = "oor_on_edge"
-version = "1.0.1"
+version = "1.0.2"
 description = "OOR on-edge is about on-edge recognition of objects from public space images."
 authors = [
     "Sebastian Davrieux <s.davrieux@amsterdam.nl>",


### PR DESCRIPTION
New naming convention:
- each CSV file now has a new timestamp
- JPGs have the same prefix number and timestamp as the corresponding CSV

This code was deployed on 11/11/24 and works fine.